### PR TITLE
add compatibility for all versions of Node

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,14 @@ const fs = require('fs')
 const url = require('url');
 const querystring = require('querystring');
 const figlet = require('figlet')
-const fetch = require('node-fetch');
+
+//This conditional checks to see if the installed version of Node is older than version 18,
+//and defines 'fetch' if the installed version is older. This is because 'fetch' was introduced as a default
+//module in Node 18 (on April 19, 2022), so if you try to define 'fetch' in v18 or above, it will break the code.
+if (Number(process.version.substring(1,3)) < 18){
+  const fetch = require('node-fetch');
+}
+
 
 
 


### PR DESCRIPTION
This update adds a conditional statement that checks the version of Node. If the version is older than Node 18, it defines 'fetch'. If you try to define 'fetch' in Node 18 or above, it breaks the code.